### PR TITLE
docs: improve Mokksy positioning and onboarding

### DIFF
--- a/docs/config/_default/menus/menu.en.yaml
+++ b/docs/config/_default/menus/menu.en.yaml
@@ -7,13 +7,13 @@ footer:
   - name: Docs
     url: /docs/
     weight: 10
+
+  - name: Docs for Agents
+    url: /llms.txt
+    weight: 20
+
   - name: GitHub
-    url: https://github.com/mokksy/mokksy/
+    url: https://github.com/mokksy/
     weight: 30
-    params:
-      external: true
-  - name: Author
-    url: https://kpavlov.me
-    weight: 40
     params:
       external: true

--- a/docs/config/_default/params.yaml
+++ b/docs/config/_default/params.yaml
@@ -1,5 +1,5 @@
 description: >-
-  Mokksy & AI-Mocks — mock HTTP and LLM servers for Kotlin & JVM
+  Mokksy and AI-Mocks - mock HTTP APIs with real-world behavior for Java and Kotlin integration tests
 github: https://github.com/mokksy/mokksy
 api_docs_mokksy: https://mokksy.github.io/mokksy/
 api_docs_ai_mocks: https://mokksy.github.io/ai-mocks/
@@ -32,26 +32,26 @@ author:
 
 features:
   - icon: ⚡️
-    title: True Streaming
+    title: True SSE and Streaming
     description: >-
-      Native Server-Side Events support. Simulate chunked token delivery just like real LLM APIs — with configurable delays between chunks.
+      Native Server-Sent Events and chunked response streams with controllable timing between chunks.
   - icon: 🎯
     title: Request Matching
     description: >-
-      Fluent Kotlin DSL for matching requests by model, prompt content, parameters, and headers. Return different responses per scenario.
+      Match paths, headers, request bodies, multipart uploads, and typed payloads with a fluent Java API and Kotlin DSL.
   - icon: 💥
-    title: Error Simulation
+    title: Failure Simulation
     description: >-
-      Mock rate limits, token exhaustion, network timeouts, and provider-specific error formats. Test unhappy paths reliably.
+      Model slow responses, retry-after headers, rate limits, malformed payloads, hanging streams, and timeout paths.
   - icon: ⏱
-    title: Latency Control
+    title: Deterministic CI Tests
     description: >-
-      Add configurable delays at request level or between individual streaming chunks. Reproduce real-world performance conditions in tests.
+      Run integration tests locally and in CI without API keys, provider quotas, network flakiness, or rate limits.
   - icon: 🔌
-    title: Drop-in Compatible
+    title: Framework Friendly
     description: >-
-      Point your existing Anthropic, OpenAI, or Gemini SDK client at the mock server URL. No code changes needed in your application.
+      Use Mokksy with Spring Boot, Quarkus, Ktor, JVM SDK clients, and any HTTP client that accepts a base URL.
   - icon: 🧪
-    title: Kotest Ready
+    title: AI-Mocks Layer
     description: >-
-      First-class Kotest integration with fluent assertions, concise test DSL, and full JUnit 5 support for Java teams.
+      Add provider-specific OpenAI, Anthropic, Gemini, Ollama, and A2A mocks when the dependency is an AI API.

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1,18 +1,20 @@
 ---
-title: "Mokksy and AI-Mocks"
+title: "Mokksy: HTTP mock server for Kotlin and Java integration tests"
 description: |-
-  Mokksy & AI-Mocks: The modern mock HTTP server for Kotlin & Ktor. High-fidelity mocking for OpenAI, Anthropic, Gemini, and SSE streaming where WireMock falls short.
+  Mock HTTP APIs with real-world behavior. Mokksy is a Kotlin and Java HTTP mock server for integration testing, SSE testing, streaming API testing, and failure simulation.
 Keywords:
+  - mock HTTP server
+  - HTTP mocking for Kotlin
+  - HTTP mocking for Java
+  - integration testing
+  - SSE testing
+  - streaming API testing
+  - WireMock alternative
+  - failure simulation
+  - Kotlin
+  - Java
   - Mokksy
   - AI-Mocks
-  - Mock HTTP server
-  - Kotlin
-  - Ktor
-  - OpenAI
-  - Anthropic
-  - Gemini
-  - SSE
-  - streaming
 ---
 
 Root page metadata (`title`, `description`, keywords) lives here. Visible homepage sections and chip links are in **`data/home.yaml`**. Hero carousel **Kotlin/Java samples** are markdown pages under **`content/home/examples/`** (see that folder’s `_index.md` manifest). The six feature cards use **`params.features`** in **`config/_default/params.yaml`**. Layout: **`themes/mokksy/layouts/index.html`** and **`layouts/partials/home/*.html`**.

--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -2,13 +2,34 @@
 title: "Mokksy and AI-Mocks"
 #weight: 1
 summary: |-
-  Integration guides for Mokksy: Set up mock servers for LangChain4j, Spring-AI, and Google Gen AI Java SDK. Complete documentation for AI response simulation.
+  Documentation for Mokksy and AI-Mocks. Start with HTTP integration testing, then add provider-specific AI mocks when your dependency is an LLM API.
 ---
 
-Welcome to the Mokksy and AI-Mocks documentation. This documentation will help you get started with using Mokksy and AI-Mocks for mocking HTTP and LLM APIs in your projects.
+Mokksy helps Kotlin and Java teams replace external HTTP services in integration tests. Use it for deterministic stubs, real request matching, streaming responses, SSE, and failure simulation.
 
-- [Mokksy](./mokksy/)
-- AI-Mocks
+AI-Mocks is built on Mokksy. Use it when the external dependency is an AI provider and you want OpenAI, Anthropic, Gemini, Ollama, or Agent-to-Agent API behavior without API keys, rate limits, or provider outages.
+
+## Start here
+
+- [Quick Start (5 minutes)](./mokksy/quick-start/)
+- [First integration test](./mokksy/first-integration-test/)
+- [Streaming test example](./mokksy/streaming-test-example/)
+- [Failure simulation recipes](./mokksy/failure-simulation/)
+
+## Mokksy
+
+- [Mokksy overview](./mokksy/)
+- [Why Mokksy vs WireMock](./mokksy/wiremock-alternative/)
+- [Stubbing responses](./mokksy/stubbing/)
+- [Request matching](./mokksy/request-matching/)
+- [Streaming and SSE](./mokksy/streaming/)
+- [Multipart and file uploads](./mokksy/multipart/)
+- [Verification and request journal](./mokksy/verification/)
+- [Ecosystem integrations](./mokksy/ecosystem-integrations/)
+
+## AI-Mocks
+
+- [AI-Mocks overview](./ai-mocks/)
   - [OpenAI](./ai-mocks/openai/)
   - [Anthropic](./ai-mocks/anthropic/)
   - [Gemini](./ai-mocks/gemini/)
@@ -17,4 +38,5 @@ Welcome to the Mokksy and AI-Mocks documentation. This documentation will help y
 
 ## API Reference
 
-For detailed API documentation, please visit the [API Reference](https://mokksy.dev/apidocs/).
+- [Mokksy API](https://mokksy.github.io/mokksy/)
+- [AI Mocks API](https://mokksy.github.io/ai-mocks/)

--- a/docs/content/docs/ai-mocks/_index.md
+++ b/docs/content/docs/ai-mocks/_index.md
@@ -1,12 +1,14 @@
 ---
 title: "AI-Mocks"
 weight: 30
-sumamry: |-
-  Official Mokksy Documentation: Get started with mock HTTP and LLM servers. Setup guides for SSE streaming, error simulation, and agent-to-agent protocols.
+summary: |-
+  Provider-specific AI mocking toolkit built on Mokksy. Test OpenAI, Anthropic, Gemini, Ollama, and Agent-to-Agent clients without real provider calls.
 ---
 [![Maven Central](https://img.shields.io/maven-central/v/dev.mokksy.aimocks/ai-mocks-core.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/dev.mokksy.aimocks/ai-mocks-core)
 
-AI-Mocks provides specialized mock server implementations built on top of Mokksy for testing and development with LLM APIs.
+AI-Mocks provides specialized mock server implementations built on top of Mokksy for testing and development with AI provider APIs.
+
+Use Mokksy directly when you need a general HTTP/SSE mock server. Use AI-Mocks when your dependency is an AI provider SDK and you want provider-specific request builders, response formats, streaming behavior, and error payloads.
 
 ## Supported Providers
 

--- a/docs/content/docs/mokksy/_index.md
+++ b/docs/content/docs/mokksy/_index.md
@@ -1,32 +1,50 @@
 ---
 title: Mokksy
 weight: 10
-description: Modern mock HTTP server for Kotlin & Java
+description: Mock HTTP APIs with real-world behavior in Kotlin and Java integration tests.
 summary: |-
-  Mokksy: The modern mock HTTP server for Kotlin and Java built with Ktor. Unlike WireMock, Mokksy provides true SSE and streaming response support for advanced integration testing.
+  Mokksy is a mock HTTP server for Kotlin and Java integration testing. Use it to test real HTTP behavior, SSE, streaming APIs, deterministic failures, retries, and timeouts.
 ---
 [![Maven Central](https://img.shields.io/maven-central/v/dev.mokksy/mokksy.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/dev.mokksy/mokksy)
+[![GitHub stars](https://img.shields.io/github/stars/mokksy/mokksy?style=social)](https://github.com/mokksy/mokksy)
 
 ## Why Mokksy?
 
-WireMock does not support true SSE and streaming responses.
+Mokksy replaces external HTTP dependencies in integration tests. Point your application or SDK client at a local Mokksy server, define the responses you expect, and run the test without real network calls.
 
-Mokksy is here to address those limitations.
-Particularly, it might be useful for integration testing LLM clients.
+It is especially useful when static JSON responses are not enough: streaming APIs, Server-Sent Events (SSE), delayed chunks, retry scenarios, file uploads, and failure paths.
 
 ## Key Features
 
-- **Streaming Support**: True support for streaming responses and [Server-Side Events (SSE)][sse]
-- **Response Control**: Flexibility to control server responses directly via `ApplicationCall` object
-- **Delay Simulation**: Support for simulating response delays and delays between chunks
-- **Modern API**: Fluent Kotlin DSL API with [Kotest Assertions](https://kotest.io/docs/assertions/assertions.html)
-- **Error Simulation**: Ability to mock negative scenarios and error responses
+- **Streaming Support**: true support for streaming responses and [Server-Side Events (SSE)][sse]
+- **Response Control**: define HTTP status, headers, body content, stream chunks, and delays in test code
+- **Delay Simulation**: simulate response delays and delays between individual chunks
+- **Failure Simulation**: model rate limits, retry-after responses, malformed payloads, hanging streams, and timeout paths
 - **Specificity-Based Matching**: When multiple stubs match a request, Mokksy automatically selects the most specific
   one — no explicit priority configuration required for common cases
 - **Ktor Integration**: Embed Mokksy into any existing Ktor application via `Application.mokksy()` and `Route.mokksy()`
   extension functions — including behind authentication middleware
+- **AI-Mocks Layer**: use provider-specific OpenAI, Anthropic, Gemini, Ollama, and A2A mocks when the dependency is an AI API
+
+## Product architecture
+
+```text
+Application under test -> Mokksy -> Stubbed external HTTP API
+```
+
+```text
+Client opens SSE connection -> Mokksy sends event chunks -> Client handles completion, delay, or timeout
+```
+
+```text
+AI-Mocks provider DSL -> Mokksy HTTP/SSE server -> OpenAI/Anthropic/Gemini-compatible responses
+```
+
+Mokksy is the core HTTP and SSE mock server. AI-Mocks is built on top of Mokksy and adds provider-specific APIs for AI SDKs.
 
 ## Quick start
+
+For the fastest path, start with [Quick Start (5 minutes)](./quick-start/).
 
 1. Add dependencies:
 {{< code-tabs >}}
@@ -104,15 +122,31 @@ val client = HttpClient {
 }
 ```
 {{< /tab >}}
+{{< tab lang="java" >}}
+```java
+var httpClient = HttpClient.newHttpClient();
+
+var request = HttpRequest.newBuilder()
+    .uri(URI.create(mokksy.baseUrl() + "/ping"))
+    .GET()
+    .build();
+```
+{{< /tab >}}
 {{< /code-tabs >}}
 
 ## Sections
 
+- [Quick Start (5 minutes)](./quick-start/) — install Mokksy and run the first stub
+- [First integration test](./first-integration-test/) — replace a real HTTP dependency
+- [Streaming test example](./streaming-test-example/) — test SSE and chunked responses
+- [Failure simulation recipes](./failure-simulation/) — delays, timeouts, rate limits, and malformed streams
+- [Mokksy vs WireMock](./wiremock-alternative/) — streaming-focused comparison
 - [Stubbing responses](./stubbing/) — GET, POST, typed body, status-only
 - [Multipart and file uploads](./multipart/) — forms, uploaded files, multipart/mixed
 - [Streaming and SSE](./streaming/) — SSE streams, long-lived connections
 - [Request matching](./request-matching/) — matchers, specificity, priority
 - [Verification and request journal](./verification/) — verify stubs, journal modes
 - [Ktor integration](./ktor/) — embed in existing Ktor applications
+- [Ecosystem integrations](./ecosystem-integrations/) — Spring Boot, Quarkus, SDKs, and AI frameworks
 
 [sse]: https://html.spec.whatwg.org/multipage/server-sent-events.html "Server-Side Events Specification"

--- a/docs/content/docs/mokksy/ecosystem-integrations.md
+++ b/docs/content/docs/mokksy/ecosystem-integrations.md
@@ -1,0 +1,71 @@
+---
+title: "Ecosystem integrations"
+slug: integrations
+weight: 75
+toc: true
+summary: |-
+  Use Mokksy with Spring Boot, Ktor, Quarkus, JVM SDK clients, LangChain4j, Spring AI, OpenAI SDK, and Anthropic SDK.
+---
+
+Mokksy works with any framework or SDK that can be pointed at a configurable base URL.
+
+## Spring Boot
+
+Start Mokksy in your test fixture, then inject `mokksy.baseUrl()` into the HTTP client or application property that normally points at the external service.
+
+```text
+Spring Boot test -> application HTTP client -> Mokksy -> stubbed external API
+```
+
+Use this for payment gateways, fraud/risk APIs, document services, or internal platform dependencies.
+
+## Ktor
+
+Use [Ktor integration](../ktor/) when you want Mokksy to live inside an existing Ktor application. Use the standalone server when your application only needs a replacement base URL.
+
+## Quarkus
+
+Use the same pattern as Spring Boot: start Mokksy before the test, set the dependency base URL to `mokksy.baseUrl()`, and run the application through its real HTTP client.
+
+Demos:
+- ["LangChain4j with Quarkus (KotlinConf`25)"](https://2025.kotlinconf.com/talks/795976/)
+    - ["Financial Assistant Chatbot with Easy RAG"](https://github.com/kpavlov/quarkus-assistant-demo) ([SentimentAnalyzerTest](https://github.com/kpavlov/quarkus-assistant-demo/blob/main/src/test/kotlin/com/example/chatbot/SentimentAnalyzerTest.kt))
+- ["Quarkus LC4J Demo"](https://github.com/kpavlov/quarkus-ai-demo/tree/main#demo-2---service-with-mock-openai) (archive)
+
+## LangChain4j
+
+Use AI-Mocks when the dependency is an AI provider. Start with:
+
+- [OpenAI with LangChain4j](../../ai-mocks/openai/#integration-with-langchain4j)
+- [Anthropic with LangChain4j](../../ai-mocks/anthropic/#integration-with-langchain4j)
+- [Ollama with LangChain4j](../../ai-mocks/ollama/#integration-with-langchain4j)
+
+Demos:
+
+- ["LangChain4j with Quarkus (KotlinConf`25)"](https://2025.kotlinconf.com/talks/795976/)
+  - ["Financial Assistant Chatbot with Easy RAG"](https://github.com/kpavlov/quarkus-assistant-demo) ([SentimentAnalyzerTest](https://github.com/kpavlov/quarkus-assistant-demo/blob/main/src/test/kotlin/com/example/chatbot/SentimentAnalyzerTest.kt))
+
+## Spring AI
+
+Use AI-Mocks for provider-compatible responses:
+
+- [OpenAI with Spring AI](../../ai-mocks/openai/#integration-with-spring-ai)
+- [Gemini with Spring AI](../../ai-mocks/gemini/#integration-with-spring-ai)
+
+## OpenAI SDK
+
+Use [AI-Mocks OpenAI](../../ai-mocks/openai/) when your application uses the official OpenAI SDK. Configure the SDK with the mock server base URL and a dummy API key.
+
+## Anthropic SDK
+
+Use [AI-Mocks Anthropic](../../ai-mocks/anthropic/) when your application uses the official Anthropic SDK. Configure the SDK with the mock server base URL and a dummy API key.
+
+## Koog
+
+[Koog](https://koog.ai) is an AI framework from JetBrains. You can absolutely test Koog applications with Mokksy/AI Mocks.
+
+Demos:
+- ["Koog Spring-Boot Elven Assistant" (Devoxx Belgium 2025)](https://github.com/kpavlov/koog-spring-boot-assistant)
+   - Video: ["Testing Challenges in the Age of AI"](https://www.youtube.com/watch?v=IwAsq3EfaC0)
+   - [Slides](https://speakerdeck.com/kpavlov/testing-challenges-in-the-age-of-ai-devoxx-dot-be-2025)
+

--- a/docs/content/docs/mokksy/failure-simulation.md
+++ b/docs/content/docs/mokksy/failure-simulation.md
@@ -1,0 +1,161 @@
+---
+title: "Failure simulation recipes"
+weight: 8
+toc: true
+summary: |-
+  Recipes for delayed responses, hanging streams, timeout paths, rate limits, retry-after responses, and malformed streaming data.
+---
+
+Production HTTP clients need more than happy-path JSON. Use these recipes to verify retries, backoff, timeouts, stream parsing, and fallback behavior.
+
+## Delayed response
+
+{{< code-tabs >}}
+{{< tab lang="kotlin" >}}
+```kotlin
+mokksy.get {
+  path("/slow")
+} respondsWith {
+  delay = 2.seconds
+  body = "eventually-ok"
+}
+```
+{{< /tab >}}
+{{< tab lang="java" >}}
+```java
+mokksy.get(spec -> spec.path("/slow"))
+    .respondsWith(response -> response
+        .delayMillis(2_000)
+        .body("eventually-ok"));
+```
+{{< /tab >}}
+{{< /code-tabs >}}
+
+## Delayed chunks
+
+{{< code-tabs >}}
+{{< tab lang="kotlin" >}}
+```kotlin
+mokksy.get {
+  path("/slow-stream")
+} respondsWithStream {
+  delayBetweenChunks = 500.milliseconds
+  chunks += "first\n"
+  chunks += "second\n"
+}
+```
+{{< /tab >}}
+{{< tab lang="java" >}}
+```java
+mokksy.get(spec -> spec.path("/slow-stream"))
+    .respondsWithStream(stream -> stream
+        .delayBetweenChunksMillis(500)
+        .chunk("first\n")
+        .chunk("second\n"));
+```
+{{< /tab >}}
+{{< /code-tabs >}}
+
+## Hanging request or stream
+
+{{< code-tabs >}}
+{{< tab lang="kotlin" >}}
+```kotlin
+mokksy.get {
+  path("/never-finishes")
+} respondsWithSseStream {
+  flow = flow {
+    emit(ServerSentEvent(data = "started"))
+    awaitCancellation()
+  }
+}
+```
+{{< /tab >}}
+{{< tab lang="java" >}}
+```java
+mokksy.get(spec -> spec.path("/never-finishes"))
+    .respondsWithSseStream(stream -> stream
+        .chunks(Stream.generate(() -> SseEvent.data("heartbeat")))
+        .delayBetweenChunksMillis(1_000));
+```
+{{< /tab >}}
+{{< /code-tabs >}}
+
+Use this with a short client timeout to verify timeout handling.
+
+## Retry-after and rate limiting
+
+{{< code-tabs >}}
+{{< tab lang="kotlin" >}}
+```kotlin
+mokksy.post {
+  path("/payments")
+} respondsWith {
+  httpStatus = HttpStatusCode.TooManyRequests
+  headers += HttpHeaders.RetryAfter to "30"
+  body = """{"error":"rate_limited"}"""
+}
+```
+{{< /tab >}}
+{{< tab lang="java" >}}
+```java
+mokksy.post(spec -> spec.path("/payments"))
+    .respondsWith(response -> response
+        .status(429)
+        .header("Retry-After", "30")
+        .body("{\"error\":\"rate_limited\"}"));
+```
+{{< /tab >}}
+{{< /code-tabs >}}
+
+## Malformed SSE
+
+{{< code-tabs >}}
+{{< tab lang="kotlin" >}}
+```kotlin
+mokksy.get {
+  path("/malformed-events")
+} respondsWithStream {
+  contentType = ContentType.Text.EventStream
+  chunks += "data: valid\n\n"
+  chunks += "this is not a valid event frame"
+}
+```
+{{< /tab >}}
+{{< tab lang="java" >}}
+```java
+mokksy.get(spec -> spec.path("/malformed-events"))
+    .respondsWithStream(stream -> stream
+        .contentType("text/event-stream")
+        .chunk("data: valid\n\n")
+        .chunk("this is not a valid event frame"));
+```
+{{< /tab >}}
+{{< /code-tabs >}}
+
+## Partial failure
+
+{{< code-tabs >}}
+{{< tab lang="kotlin" >}}
+```kotlin
+mokksy.get {
+  path("/statement")
+} respondsWithStream {
+  chunks += "header\n"
+  chunks += "row-1\n"
+  delayBetweenChunks = 250.milliseconds
+}
+```
+{{< /tab >}}
+{{< tab lang="java" >}}
+```java
+mokksy.get(spec -> spec.path("/statement"))
+    .respondsWithStream(stream -> stream
+        .chunk("header\n")
+        .chunk("row-1\n")
+        .delayBetweenChunksMillis(250));
+```
+{{< /tab >}}
+{{< /code-tabs >}}
+
+Keep the client timeout lower than the full expected transfer time to verify partial-data handling.

--- a/docs/content/docs/mokksy/first-integration-test.md
+++ b/docs/content/docs/mokksy/first-integration-test.md
@@ -1,0 +1,90 @@
+---
+title: "First integration test"
+weight: 6
+toc: true
+summary: |-
+  Replace a real external HTTP service with Mokksy and verify your application behavior through a real client call.
+---
+
+Use Mokksy when your code normally calls an external HTTP API: payments, customer data, fraud scoring, telecom provisioning, document processing, or internal platform services.
+
+```text
+Application under test -> Mokksy -> Stubbed external HTTP API
+```
+
+## Test shape
+
+1. Start Mokksy on a random local port.
+2. Configure the application under test to use `mokksy.baseUrl()`.
+3. Stub the external endpoint and response.
+4. Execute the real application behavior.
+5. Verify the response and the request journal.
+
+## Example
+
+{{< code-tabs >}}
+{{< tab lang="kotlin" >}}
+```kotlin
+val mokksy = Mokksy(verbose = true).start()
+val client = HttpClient {
+  install(DefaultRequest) {
+    url(mokksy.baseUrl())
+  }
+}
+
+mokksy.post {
+  path("/risk/check")
+  bodyContains("customer-123")
+} respondsWith {
+  httpStatus = HttpStatusCode.Accepted
+  body = """{"decision":"review"}"""
+}
+
+val response = client.post("/risk/check") {
+  contentType(ContentType.Application.Json)
+  setBody("""{"customerId":"customer-123","amount":2500}""")
+}
+
+response.status shouldBe HttpStatusCode.Accepted
+response.bodyAsText() shouldBe """{"decision":"review"}"""
+
+mokksy.verifyNoUnexpectedRequests()
+mokksy.verifyNoUnmatchedStubs()
+```
+{{< /tab >}}
+{{< tab lang="java" >}}
+```java
+var mokksy = Mokksy.create().start();
+var httpClient = HttpClient.newHttpClient();
+
+try {
+    mokksy.post(spec -> spec
+        .path("/risk/check")
+        .bodyContains("customer-123")
+    ).respondsWith(response -> response
+        .status(202)
+        .body("{\"decision\":\"review\"}"));
+
+    var response = httpClient.send(
+        HttpRequest.newBuilder()
+            .uri(URI.create(mokksy.baseUrl() + "/risk/check"))
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(
+                "{\"customerId\":\"customer-123\",\"amount\":2500}"
+            ))
+            .build(),
+        HttpResponse.BodyHandlers.ofString()
+    );
+
+    assertThat(response.statusCode()).isEqualTo(202);
+    assertThat(response.body()).isEqualTo("{\"decision\":\"review\"}");
+
+    mokksy.verifyNoUnexpectedRequests();
+} finally {
+    mokksy.shutdown();
+}
+```
+{{< /tab >}}
+{{< /code-tabs >}}
+
+This catches two important integration failures: your code sent the wrong request, or it did not call the dependency at all.

--- a/docs/content/docs/mokksy/ktor-integration.md
+++ b/docs/content/docs/mokksy/ktor-integration.md
@@ -26,7 +26,7 @@ val server = MokksyServer()
 server.get { path("/ping") } respondsWith { body = "pong" }
 
 embeddedServer(Netty, port = 8080) {
-  mokksy(server)
+    mokksy(server)
 }.start(wait = true)
 ```
 {{< /tab >}}
@@ -57,8 +57,8 @@ fun Application.configure() {
 {{< tab lang="kotlin" >}}
 ```kotlin
 routing {
-  get("/health") { call.respondText("OK") }
-  mokksy(server)
+    get("/health") { call.respondText("OK") }
+    mokksy(server)
 }
 ```
 {{< /tab >}}
@@ -78,19 +78,19 @@ install(SSE)
 install(DoubleReceive)
 install(ContentNegotiation) { json() }
 install(Authentication) {
-  basic("auth-basic") {
-    validate { credentials ->
-      if (credentials.name == "user" && credentials.password == "pass") {
-        UserIdPrincipal(credentials.name)
-      } else null
-    }
+    basic("auth-basic") {
+        validate { credentials ->
+            if (credentials.name == "user" && credentials.password == "pass") {
+              UserIdPrincipal(credentials.name)
+            } else null
+        }
   }
 }
 
 routing {
-  authenticate("auth-basic") {
-    mokksy(server)
-  }
+    authenticate("auth-basic") { 
+        mokksy(server)
+    }
 }
 ```
 {{< /tab >}}

--- a/docs/content/docs/mokksy/quick-start.md
+++ b/docs/content/docs/mokksy/quick-start.md
@@ -1,0 +1,103 @@
+---
+title: "Quick Start (5 minutes)"
+weight: 5
+slug: quick-start
+toc: true
+summary: |-
+  Install Mokksy, start a local HTTP mock server, and run a first deterministic integration test in minutes.
+---
+
+This guide gets you from an empty test to a local HTTP mock server. You will stub one endpoint, call it through a real HTTP client, and verify the response.
+
+## Add the test dependency
+
+{{< code-tabs >}}
+{{< tab lang="kotlin" filename="build.gradle.kts" >}}
+```kotlin
+dependencies {
+  testImplementation("dev.mokksy:mokksy-jvm:$latestVersion")
+}
+```
+{{< /tab >}}
+{{< tab lang="xml" filename="pom.xml" >}}
+```xml
+<dependency>
+  <groupId>dev.mokksy</groupId>
+  <artifactId>mokksy-jvm</artifactId>
+  <version>[LATEST_VERSION]</version>
+  <scope>test</scope>
+</dependency>
+```
+{{< /tab >}}
+{{< /code-tabs >}}
+
+## Stub and call an HTTP endpoint
+
+{{< code-tabs >}}
+{{< tab lang="kotlin" >}}
+```kotlin
+// before SUT starts
+val mokksy = Mokksy(verbose = true).start()
+
+// SUT setup
+val client = HttpClient {
+  install(DefaultRequest) {
+    url(mokksy.baseUrl())
+  }
+}
+
+// Given - before test
+mokksy.get {
+  path("/accounts/42")
+} respondsWith {
+  body = """{"id":"42","status":"active"}"""
+  httpStatus = HttpStatusCode.OK
+}
+
+// When
+val response = client.get("/accounts/42")
+
+// Then
+response.status shouldBe HttpStatusCode.OK
+response.bodyAsText() shouldBe """{"id":"42","status":"active"}"""
+```
+{{< /tab >}}
+{{< tab lang="java" >}}
+```java
+// before SUT starts
+var mokksy = Mokksy.create().start();
+
+// Given - before test
+mokksy.get(spec -> spec.path("/accounts/42"))
+    .respondsWith(response -> response
+        .body("{\"id\":\"42\",\"status\":\"active\"}")
+        .status(200));
+
+// When
+var httpClient = HttpClient.newHttpClient();
+var response = httpClient.send(
+    HttpRequest.newBuilder()
+        .uri(URI.create(mokksy.baseUrl() + "/accounts/42"))
+        .GET()
+        .build(),
+    HttpResponse.BodyHandlers.ofString()
+);
+
+// Then
+assertThat(response.statusCode()).isEqualTo(200);
+assertThat(response.body()).isEqualTo("{\"id\":\"42\",\"status\":\"active\"}");
+
+// after SUT stop (or never)
+mokksy.shutdown();
+
+```
+{{< /tab >}}
+{{< /code-tabs >}}
+
+## What this proves
+
+- Your test talks to a real HTTP server.
+- The external service is replaced by Mokksy.
+- The response is deterministic and can run in CI without API keys or network access.
+
+Next, build a complete [first integration test](../first-integration-test/) or test a [streaming API](../streaming-test-example/).

--- a/docs/content/docs/mokksy/request-matching.md
+++ b/docs/content/docs/mokksy/request-matching.md
@@ -88,6 +88,37 @@ val genericResult = client.post("/users") { setBody("regular") }
 genericResult.bodyAsText() shouldBe "any user"
 ```
 {{< /tab >}}
+{{< tab lang="java" >}}
+```java
+// Generic: matches any POST to /users
+mokksy.post(spec -> spec.path("/users"))
+    .respondsWith(response -> response.body("any user"));
+
+// Specific: matches only requests whose body contains "admin"
+mokksy.post(spec -> spec
+    .path("/users")
+    .bodyContains("admin")
+).respondsWith(response -> response.body("admin user"));
+
+var adminResult = httpClient.send(
+    HttpRequest.newBuilder()
+        .uri(URI.create(mokksy.baseUrl() + "/users"))
+        .POST(HttpRequest.BodyPublishers.ofString("admin"))
+        .build(),
+    HttpResponse.BodyHandlers.ofString()
+);
+assertThat(adminResult.body()).isEqualTo("admin user");
+
+var genericResult = httpClient.send(
+    HttpRequest.newBuilder()
+        .uri(URI.create(mokksy.baseUrl() + "/users"))
+        .POST(HttpRequest.BodyPublishers.ofString("regular"))
+        .build(),
+    HttpResponse.BodyHandlers.ofString()
+);
+assertThat(genericResult.body()).isEqualTo("any user");
+```
+{{< /tab >}}
 {{< /code-tabs >}}
 
 <!--- INCLUDE

--- a/docs/content/docs/mokksy/streaming-test-example.md
+++ b/docs/content/docs/mokksy/streaming-test-example.md
@@ -1,0 +1,66 @@
+---
+title: "Streaming test example"
+weight: 7
+slug: streaming-test-example
+toc: true
+summary: |-
+  Test Server-Sent Events and chunked streaming responses with controlled timing between chunks.
+---
+
+Streaming clients fail in ways static JSON tests cannot catch: missed chunks, early completion, timeout handling, buffering, and reconnect logic.
+
+```text
+Client opens SSE connection -> Mokksy sends event chunks -> Client handles stream completion, delay, or timeout
+```
+
+## SSE response with chunk delays
+
+{{< code-tabs >}}
+{{< tab lang="kotlin" >}}
+```kotlin
+mokksy.get {
+  path("/events")
+} respondsWithSseStream {
+  delayBetweenChunks = 100.milliseconds
+  chunks += ServerSentEvent(data = """{"status":"accepted"}""")
+  chunks += ServerSentEvent(data = """{"status":"processed"}""")
+}
+```
+{{< /tab >}}
+{{< tab lang="java" >}}
+```java
+mokksy.get(spec -> spec.path("/events"))
+    .respondsWithSseStream(stream -> stream
+        .delayBetweenChunksMillis(100)
+        .chunk(SseEvent.data("{\"status\":\"accepted\"}"))
+        .chunk(SseEvent.data("{\"status\":\"processed\"}")));
+```
+{{< /tab >}}
+{{< /code-tabs >}}
+
+## Plain text stream
+
+{{< code-tabs >}}
+{{< tab lang="kotlin" >}}
+```kotlin
+mokksy.get {
+  path("/download")
+} respondsWithStream {
+  delayBetweenChunks = 50.milliseconds
+  chunks += "part-1\n"
+  chunks += "part-2\n"
+}
+```
+{{< /tab >}}
+{{< tab lang="java" >}}
+```java
+mokksy.get(spec -> spec.path("/download"))
+    .respondsWithStream(stream -> stream
+        .delayBetweenChunksMillis(50)
+        .chunk("part-1\n")
+        .chunk("part-2\n"));
+```
+{{< /tab >}}
+{{< /code-tabs >}}
+
+Use these examples to test code that processes data before the full response is available.

--- a/docs/content/docs/mokksy/streaming.md
+++ b/docs/content/docs/mokksy/streaming.md
@@ -123,6 +123,14 @@ flow = flow {
 }
 ```
 {{< /tab >}}
+{{< tab lang="java" >}}
+```java
+mokksy.post(spec -> spec.path("/sse-ll"))
+    .respondsWithSseStream(stream -> stream
+        .chunks(Stream.generate(() -> SseEvent.data("heartbeat")))
+        .delayBetweenChunksMillis(1_000));
+```
+{{< /tab >}}
 {{< /code-tabs >}}
 <!--- INCLUDE
         }

--- a/docs/content/docs/mokksy/stubbing.md
+++ b/docs/content/docs/mokksy/stubbing.md
@@ -259,6 +259,12 @@ data class CreateItemRequest(val name: String, val quantity: Int)
 data class CreateItemResponse(val message: String)
 ```
 {{< /tab >}}
+{{< tab lang="java" >}}
+```java
+record CreateItemRequest(String name, int quantity) {}
+record CreateItemResponse(String message) {}
+```
+{{< /tab >}}
 {{< /code-tabs >}}
 
 ### Reified overloads
@@ -499,6 +505,30 @@ mokksy.get(
 
 client.get("/once").status shouldBe HttpStatusCode.OK
 client.get("/once").status shouldBe HttpStatusCode.NotFound
+```
+{{< /tab >}}
+{{< tab lang="java" >}}
+```java
+mokksy.get(StubConfiguration.once("single-use"), spec -> spec.path("/once"))
+    .respondsWith(response -> response.body("First and only response"));
+
+var first = httpClient.send(
+    HttpRequest.newBuilder()
+        .uri(URI.create(mokksy.baseUrl() + "/once"))
+        .GET()
+        .build(),
+    HttpResponse.BodyHandlers.ofString()
+);
+assertThat(first.statusCode()).isEqualTo(200);
+
+var second = httpClient.send(
+    HttpRequest.newBuilder()
+        .uri(URI.create(mokksy.baseUrl() + "/once"))
+        .GET()
+        .build(),
+    HttpResponse.BodyHandlers.ofString()
+);
+assertThat(second.statusCode()).isEqualTo(404);
 ```
 {{< /tab >}}
 {{< /code-tabs >}}

--- a/docs/content/docs/mokksy/verification.md
+++ b/docs/content/docs/mokksy/verification.md
@@ -29,6 +29,12 @@ fun main() {
 mokksy.verifyNoUnmatchedStubs()
 ```
 {{< /tab >}}
+{{< tab lang="java" >}}
+```java
+// Fails if any stub has never been matched
+mokksy.verifyNoUnmatchedStubs();
+```
+{{< /tab >}}
 {{< /code-tabs >}}
 
 > **Note:** Be careful when running tests in parallel against a single `MokksyServer` instance.
@@ -45,6 +51,12 @@ These requests are recorded in the `RequestJournal` and reported together.
 ```kotlin
 // Fails if any request arrived with no matching stub
 mokksy.verifyNoUnexpectedRequests()
+```
+{{< /tab >}}
+{{< tab lang="java" >}}
+```java
+// Fails if any request arrived with no matching stub
+mokksy.verifyNoUnexpectedRequests();
 ```
 {{< /tab >}}
 {{< /code-tabs >}}
@@ -135,6 +147,46 @@ class MyTest {
 }
 ```
 {{< /tab >}}
+{{< tab lang="java" >}}
+```java
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MyTest {
+
+    private final Mokksy mokksy = Mokksy.create().start();
+    private final HttpClient httpClient = HttpClient.newHttpClient();
+
+    @Test
+    void testSomething() throws Exception {
+        mokksy.get(spec -> spec.path("/hi"))
+            .respondsWith(response -> response
+                .delayMillis(100)
+                .body("Hello"));
+
+        var response = httpClient.send(
+            HttpRequest.newBuilder()
+                .uri(URI.create(mokksy.baseUrl() + "/hi"))
+                .GET()
+                .build(),
+            HttpResponse.BodyHandlers.ofString()
+        );
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.body()).isEqualTo("Hello");
+    }
+
+    @AfterEach
+    void afterEach() {
+        mokksy.verifyNoUnexpectedRequests();
+    }
+
+    @AfterAll
+    void afterAll() {
+        mokksy.verifyNoUnmatchedStubs();
+        mokksy.shutdown();
+    }
+}
+```
+{{< /tab >}}
 {{< /code-tabs >}}
 
 <!--- KNIT example-mokksy-verification-02.kt -->
@@ -163,6 +215,15 @@ val unmatchedRequests: List<RecordedRequest> = mokksy.findAllUnexpectedRequests(
 
 // List<StubHandle> — stubs that were never triggered
 val unmatchedStubs: List<StubHandle> = mokksy.findAllUnmatchedStubs()
+```
+{{< /tab >}}
+{{< tab lang="java" >}}
+```java
+// List<RecordedRequest> - HTTP requests with no matching stub
+var unmatchedRequests = mokksy.findAllUnexpectedRequests();
+
+// List<StubHandle> - stubs that were never triggered
+var unmatchedStubs = mokksy.findAllUnmatchedStubs();
 ```
 {{< /tab >}}
 {{< /code-tabs >}}

--- a/docs/content/docs/mokksy/wiremock-alternative.md
+++ b/docs/content/docs/mokksy/wiremock-alternative.md
@@ -1,0 +1,40 @@
+---
+title: "Mokksy vs WireMock"
+weight: 9
+toc: true
+summary: |-
+  Compare Mokksy and WireMock for Kotlin and Java integration testing, especially SSE, streaming APIs, and failure simulation.
+---
+
+WireMock remains a strong general-purpose HTTP stubbing tool.
+Mokksy focuses on Kotlin and Java integration tests where streaming behavior,
+Server-Sent-Events (SSE), and deterministic failure simulation matter.
+
+## Comparison
+
+| Capability                                  | Mokksy               | WireMock       |
+|---------------------------------------------|----------------------|----------------|
+| HTTP stubbing for integration tests         | **✅ Yes**            | **✅ Yes**      |
+| Request matching by path, headers, and body | **✅ Yes**            | **✅ Yes**      |
+| **True Server-Sent Events (SSE)**           | **✅ Yes**            | **❌ No**       |
+| **Chunk-level streaming responses**         | **✅ Yes**            | **❌ No**       |
+| Delays between chunks                       | **✅ Yes**            | **⚠️ Limited** |
+| **Hanging streams for timeout tests**       | **✅ Yes**            | **❌ No**       |
+| Failure simulation                          | **✅ Yes**            | **✅ Yes**      |
+| **Stream failure simulation**               | **✅ Yes**            | **❌ No**       |
+| Verification API                            | **⚠️ Limited**       | **✅ Yes**      |
+| **Kotlin DSL**                              | **✅ Yes**            | **❌ No**       |
+| **AI/LLM provider mocks**                   | **✅ Yes** (AI-Mocks) | **❌ No**       |
+| **Ktor support**                            | **✅ Yes**            | **❌ No**       |
+
+## When to choose Mokksy
+
+- You test clients that consume SSE or streaming APIs.
+- You need deterministic tests for timeouts, retries, slow chunks, and partial streams.
+- You want concise Kotlin DSLs and Java-friendly APIs in JVM test suites.
+- You use AI provider SDKs and want AI-Mocks on top of a real HTTP/SSE mock server.
+
+## When WireMock may be enough
+
+- Your tests mostly return static request/response JSON.
+- Your team already has a mature WireMock setup and does not need streaming-specific behavior.

--- a/docs/data/home.yaml
+++ b/docs/data/home.yaml
@@ -6,7 +6,7 @@ hero:
   aria_label: Hero
   mascot_alt: Mokksy mascot
   badge:
-    - "Kotlin & JVM"
+    - "Java and Kotlin"
     - "Integration Testing"
     - "Open Source"
   title:
@@ -17,10 +17,10 @@ hero:
     Mokksy is a mock HTTP server for integration testing — with true streaming,
     SSE, and failure simulation. Test your services as they behave in production.
   primary_cta:
-    label: Read the Docs
-    url: /docs/
+    label: Start in 5 minutes
+    url: /docs/mokksy/quick-start/
   github_cta:
-    label: View on GitHub
+    label: ⭐ Star on GitHub
   carousel:
     aria_label: Code examples carousel
     prev_aria: Previous example
@@ -39,41 +39,41 @@ why:
 
 integrations:
   aria_label: Supported integrations
-  label: "Tested with these LLM providers & frameworks"
+  label: "Ecosystem integrations"
   chips:
-    - { text: "🤖 Anthropic", url: /docs/ai-mocks/anthropic/ }
-    - { text: "✦ OpenAI", url: /docs/ai-mocks/openai/ }
-    - { text: "♊️ Google Gemini", url: /docs/ai-mocks/gemini/ }
-    - { text: "🦙 Ollama", url: /docs/ai-mocks/ollama/ }
-    - { text: "⇄ Agent-to-Agent (A2A)", url: /docs/ai-mocks/a2a/ }
+    - { text: "🧩 Ktor", url: /docs/mokksy/ktor/ }
+    - { text: "🌱 Spring Boot", url: /docs/mokksy/ecosystem-integrations/#spring-boot }
+    - { text: "🚀 Quarkus", url: /docs/mokksy/ecosystem-integrations/#quarkus }
+    - { text: "✦ OpenAI SDK", url: /docs/ai-mocks/openai/ }
+    - { text: "🤖 Anthropic SDK", url: /docs/ai-mocks/anthropic/ }
     - { text: "⛓🦜 LangChain4j", url: "/docs/ai-mocks/openai/#integration-with-langchain4j" }
-    - { text: "🌱 Spring AI", url: "/docs/ai-mocks/openai/#integration-with-spring-ai" }
+    - { text: "🌿 Spring AI", url: "/docs/ai-mocks/openai/#integration-with-spring-ai" }
 
 features_section:
   aria_label: Features
   id: features
   label: Why Mokksy
-  title_line1: "Everything WireMock isn't"
-  title_line2: for AI testing
+  title_line1: Test real HTTP behavior
+  title_line2: before production
   sub: |
-    Built for the unique challenges of testing LLM-powered applications —
-    streaming, chunked responses, and non-determinism included.
+    Mock streaming APIs, slow responses, retries, partial failures, and
+    connection-sensitive clients in repeatable Kotlin and Java integration tests.
 
 products:
+  label: Product architecture
+  title: "Mokksy and AI-Mocks"
   aria_label: Mokksy and AI-Mocks
-  label: Next-level mocking
-  title: "Mokksy & AI-Mocks"
   sub_html: |
-    <em>Mokksy</em> and <em>AI-Mocks</em> bring realistic behavior to HTTP and LLM API testing.
-    They let you test streaming, delays, retries, and failures — not just static responses.
+    <em>Mokksy</em> is the core HTTP and SSE mock server for integration testing.
+    <em>AI-Mocks</em> is the provider-specific AI testing toolkit built on top of Mokksy.
   cards:
     - href: /docs/mokksy/
       title: Mokksy
-      description: A Kotlin + Ktor mock HTTP server with streaming and Server-Side Events (SSE).
+      description: Replace external HTTP services in tests with deterministic stubs, streaming responses, delays, and failure simulation.
       delay: "0.1s"
     - href: /docs/ai-mocks/
       title: AI-Mocks
-      description: Built on Mokksy, providing ready-to-use mocks for OpenAI, Anthropic, Google Gemini, Ollama, and Agent-to-Agent APIs.
+      description: Provider-specific mocks for OpenAI, Anthropic, Gemini, Ollama, and Agent-to-Agent APIs, using Mokksy underneath.
       delay: "0.3s"
   bullets:
     - "<strong>Streaming & SSE:</strong> realistic response streams"
@@ -84,11 +84,11 @@ products:
   bullets_delay: "0.5s"
 
 cta:
+  title: Catch streaming failures before production
+  sub: "Run deterministic HTTP integration tests in CI without external services, API keys, rate limits, or provider outages."
   aria_label: Call to action
-  title: Start testing today
-  sub: "Open-source, MIT licensed, built for Kotlin & Java teams."
   primary:
-    label: Read the Documentation
-    url: /docs/
+    label: Start in 5 minutes
+    url: /docs/mokksy/quick-start/
   github_secondary:
     label: ⭐ Star on GitHub

--- a/docs/themes/mokksy/README.md
+++ b/docs/themes/mokksy/README.md
@@ -72,7 +72,7 @@ Control sidebar position with front matter:
 
 ```yaml
 ---
-sidebar_order: 10          # lower = higher in the list
+weight: 10                 # lower = higher in the list
 sidebar_title: "Custom"    # overrides page title in the nav
 sidebar_hide: true         # exclude from sidebar entirely
 ---

--- a/docs/themes/mokksy/layouts/partials/pagination.html
+++ b/docs/themes/mokksy/layouts/partials/pagination.html
@@ -1,4 +1,4 @@
-{{ $pages := .CurrentSection.Pages.ByParam "sidebar_order" }}
+{{ $pages := .CurrentSection.Pages.ByWeight }}
 {{ $current := . }}
 {{ $prev := "" }}
 {{ $next := "" }}

--- a/docs/themes/mokksy/layouts/partials/sidebar.html
+++ b/docs/themes/mokksy/layouts/partials/sidebar.html
@@ -29,7 +29,7 @@
   </div>
 
   {{/* Walk each top-level section under /docs */}}
-  {{ range $docsSection.Sections.ByParam "sidebar_order" }}
+  {{ range $docsSection.Sections.ByWeight }}
     {{- if not (.Params.sidebar_hide) }}
     <div class="sidebar-section">
       <p class="sidebar-section-title">
@@ -49,7 +49,7 @@
           {{ end }}
 
           {{/* Child pages sorted by sidebar_order then title */}}
-          {{ range (.Pages.ByParam "sidebar_order") }}
+          {{ range (.Pages.ByWeight) }}
             {{ if not (.Params.sidebar_hide) }}
             <li>
               <a href="{{ .RelPermalink }}"


### PR DESCRIPTION
Refresh Mokksy documentation site with new foundational guides, updated marketing copy, and a navigation infrastructure change. New pages cover quick-start setup, streaming tests, failure simulation, and ecosystem integrations. Site configuration and homepage copy are updated to emphasise HTTP testing capabilities and AI-Mocks integration. Theme templates migrate to weight-based ordering.